### PR TITLE
feat: vault read/write objects and flip context methods

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -25,15 +25,15 @@ import (
 	"go.ketch.com/lib/orlop/errors"
 )
 
-// GenerateCertificates calls Vault to generate a certificate
+// GenerateCertificatesContext calls Vault to generate a certificate
 //
-// deprecated: use GenerateCertificatesContext
-func GenerateCertificates(vault HasVaultConfig, cfg HasCertGenerationConfig, cert *[]byte, key *[]byte) error {
-	return GenerateCertificatesContext(context.TODO(), vault, cfg, cert, key)
+// deprecated: use GenerateCertificates
+func GenerateCertificatesContext(ctx context.Context, vault HasVaultConfig, cfg HasCertGenerationConfig, cert *[]byte, key *[]byte) error {
+	return GenerateCertificates(ctx, vault, cfg, cert, key)
 }
 
-// GenerateCertificatesContext calls Vault to generate a certificate
-func GenerateCertificatesContext(ctx context.Context, vault HasVaultConfig, cfg HasCertGenerationConfig, cert *[]byte, key *[]byte) error {
+// GenerateCertificates calls Vault to generate a certificate
+func GenerateCertificates(ctx context.Context, vault HasVaultConfig, cfg HasCertGenerationConfig, cert *[]byte, key *[]byte) error {
 	ctx, span := tracer.Start(ctx, "GenerateCertificates")
 	defer span.End()
 
@@ -43,7 +43,7 @@ func GenerateCertificatesContext(ctx context.Context, vault HasVaultConfig, cfg 
 	}
 
 	// Connect to Vault
-	client, err := NewVaultContext(ctx, vault)
+	client, err := NewVault(ctx, vault)
 	if err != nil {
 		return err
 	}
@@ -60,7 +60,7 @@ func GenerateCertificatesContext(ctx context.Context, vault HasVaultConfig, cfg 
 	}
 
 	// Write the params to the path to generate the certificate
-	secret, err := client.WriteContext(ctx, cfg.GetPath(), params)
+	secret, err := client.Write(ctx, cfg.GetPath(), params)
 	if err != nil {
 		err = errors.Wrap(err, "generate: failed to write to Vault")
 		span.RecordError(err)

--- a/client.go
+++ b/client.go
@@ -60,7 +60,7 @@ func ConnectContext(ctx context.Context, cfg HasClientConfig, vault HasVaultConf
 	opts = append(opts, grpc.WithChainStreamInterceptor(otelgrpc.StreamClientInterceptor()))
 
 	if cfg.GetTLS().GetEnabled() {
-		t, err := NewClientTLSConfigContext(ctx, cfg.GetTLS(), vault)
+		t, err := NewClientTLSConfig(ctx, cfg.GetTLS(), vault)
 		if err != nil {
 			span.RecordError(err)
 			return nil, errors.Wrap(err, "client: failed to get client TLS config")
@@ -78,7 +78,7 @@ func ConnectContext(ctx context.Context, cfg HasClientConfig, vault HasVaultConf
 				ctx, span := tracer.Start(ctx, "TokenProvider")
 				defer span.End()
 
-				s, err := LoadKeyContext(ctx, shared, vault, "secret")
+				s, err := LoadKey(ctx, shared, vault, "secret")
 				if err != nil {
 					span.RecordError(err)
 					logger.WithError(err).Error("client: could not load secret key")

--- a/credentials.go
+++ b/credentials.go
@@ -95,14 +95,14 @@ func GetCredentialsContext(ctx context.Context, cfg HasCredentialsConfig, vault 
 		return nil, err
 	}
 
-	client, err := NewVaultContext(ctx, vault)
+	client, err := NewVault(ctx, vault)
 	if err != nil {
 		err := errors.Wrap(err, "credentials: could not connect to Vault")
 		span.RecordError(err)
 		return nil, err
 	}
 
-	s, err := client.ReadContext(ctx, cfg.GetID())
+	s, err := client.Read(ctx, cfg.GetID())
 	if err != nil {
 		err = errors.Wrap(err, "credentials: not found")
 		span.RecordError(err)

--- a/http.go
+++ b/http.go
@@ -40,7 +40,7 @@ type HttpClient struct {
 
 // NewHttpClient creates a new HttpClient
 func NewHttpClient(ctx context.Context, cfg HasClientConfig, vault HasVaultConfig) (*HttpClient, error) {
-	ct, err := NewClientTLSConfigContext(ctx, cfg.GetTLS(), vault)
+	ct, err := NewClientTLSConfig(ctx, cfg.GetTLS(), vault)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func NewHttpClient(ctx context.Context, cfg HasClientConfig, vault HasVaultConfi
 	}
 
 	if cfg.GetToken() != nil && cfg.GetToken().GetShared() != nil {
-		if httpCli.token, err = LoadKeyContext(ctx, cfg.GetToken().GetShared(), vault, "shared"); err != nil {
+		if httpCli.token, err = LoadKey(ctx, cfg.GetToken().GetShared(), vault, "shared"); err != nil {
 			return nil, err
 		}
 	}

--- a/key.go
+++ b/key.go
@@ -33,15 +33,15 @@ import (
 	"io/ioutil"
 )
 
-// LoadKey loads the key material based on the config
+// LoadKeyContext loads the key material based on the config
 //
-// deprecated: use LoadKeyContext
-func LoadKey(cfg HasKeyConfig, vault HasVaultConfig, which string) ([]byte, error) {
-	return LoadKeyContext(context.TODO(), cfg, vault, which)
+// deprecated: use LoadKey
+func LoadKeyContext(ctx context.Context, cfg HasKeyConfig, vault HasVaultConfig, which string) ([]byte, error) {
+	return LoadKey(ctx, cfg, vault, which)
 }
 
-// LoadKeyContext loads the key material based on the config
-func LoadKeyContext(ctx context.Context, cfg HasKeyConfig, vault HasVaultConfig, which string) ([]byte, error) {
+// LoadKey loads the key material based on the config
+func LoadKey(ctx context.Context, cfg HasKeyConfig, vault HasVaultConfig, which string) ([]byte, error) {
 	ctx, span := tracer.Start(ctx, "LoadKey")
 	defer span.End()
 
@@ -87,14 +87,14 @@ func LoadKeyContext(ctx context.Context, cfg HasKeyConfig, vault HasVaultConfig,
 		return cfg.GetSecret(), nil
 
 	case "id":
-		client, err := NewVaultContext(ctx, vault)
+		client, err := NewVault(ctx, vault)
 		if err != nil {
 			err = errors.Wrap(err, "key: could not connect to Vault")
 			span.RecordError(err)
 			return nil, err
 		}
 
-		s, err := client.ReadContext(ctx, cfg.GetID())
+		s, err := client.Read(ctx, cfg.GetID())
 		if err != nil {
 			err = errors.Wrap(err, "key: not found")
 			span.RecordError(err)

--- a/server.go
+++ b/server.go
@@ -110,7 +110,7 @@ func Serve(ctx context.Context, serviceName string, options ...ServerOption) err
 
 	// Serve requests
 	if serverOptions.config.GetTLS().GetEnabled() {
-		config, err := NewServerTLSConfigContext(ctx, serverOptions.config.GetTLS(), serverOptions.vault)
+		config, err := NewServerTLSConfig(ctx, serverOptions.config.GetTLS(), serverOptions.vault)
 		if err != nil {
 			ln.Close()
 

--- a/server_options.go
+++ b/server_options.go
@@ -185,7 +185,7 @@ func (o grpcServicesServerOption) addHandler(ctx context.Context, opt *serverOpt
 
 	// If certificate file and key file have been specified then setup a TLS server
 	if opt.config.TLS.GetEnabled() {
-		t, err := NewServerTLSConfigContext(ctx, opt.config.GetTLS(), opt.vault)
+		t, err := NewServerTLSConfig(ctx, opt.config.GetTLS(), opt.vault)
 		if err != nil {
 			return errors.Wrap(err, "server: failed to load server TLS config")
 		}

--- a/tls_credentials.go
+++ b/tls_credentials.go
@@ -37,15 +37,15 @@ const (
 	TLSRootCAKey = "issuing_ca"
 )
 
-// NewServerTLSConfig returns a new tls.VaultConfig from the given configuration input
+// NewServerTLSConfigContext returns a new tls.VaultConfig from the given configuration input
 //
-// deprecated: use NewServerTLSConfigContext instead
-func NewServerTLSConfig(cfg HasTLSConfig, vault HasVaultConfig) (*tls.Config, error) {
-	return NewServerTLSConfigContext(context.TODO(), cfg, vault)
+// deprecated: use NewServerTLSConfig instead
+func NewServerTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasVaultConfig) (*tls.Config, error) {
+	return NewServerTLSConfig(ctx, cfg, vault)
 }
 
-// NewServerTLSConfigContext returns a new tls.VaultConfig from the given configuration input
-func NewServerTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasVaultConfig) (*tls.Config, error) {
+// NewServerTLSConfig returns a new tls.VaultConfig from the given configuration input
+func NewServerTLSConfig(ctx context.Context, cfg HasTLSConfig, vault HasVaultConfig) (*tls.Config, error) {
 	var err error
 
 	ctx, span := tracer.Start(ctx, "NewServerTLSConfig")
@@ -73,14 +73,14 @@ func NewServerTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasV
 
 	t := CloneTLSConfig(cfg)
 
-	err = GenerateCertificatesContext(ctx, vault, cfg.GetGenerate(), &t.Cert.Secret, &t.Key.Secret)
+	err = GenerateCertificates(ctx, vault, cfg.GetGenerate(), &t.Cert.Secret, &t.Key.Secret)
 	if err != nil {
 		err = errors.Wrap(err, "tls: failed to generate certificates")
 		span.RecordError(err)
 		return nil, err
 	}
 
-	certPEMBlock, err := LoadKeyContext(ctx, t.GetCert(), vault, TLSCertificateKey)
+	certPEMBlock, err := LoadKey(ctx, t.GetCert(), vault, TLSCertificateKey)
 	if err != nil {
 		err = errors.Wrap(err, "tls: failed to load certificate")
 		span.RecordError(err)
@@ -89,7 +89,7 @@ func NewServerTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasV
 
 	log.Trace("certificate loaded")
 
-	keyPEMBlock, err := LoadKeyContext(ctx, t.GetKey(), vault, TLSPrivateKey)
+	keyPEMBlock, err := LoadKey(ctx, t.GetKey(), vault, TLSPrivateKey)
 	if err != nil {
 		err = errors.Wrap(err, "tls: failed to load private key")
 		span.RecordError(err)
@@ -97,7 +97,7 @@ func NewServerTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasV
 	}
 
 	if t.GetRootCA().GetEnabled() {
-		rootcaPEMBlock, err := LoadKeyContext(ctx, t.GetRootCA(), vault, TLSRootCAKey)
+		rootcaPEMBlock, err := LoadKey(ctx, t.GetRootCA(), vault, TLSRootCAKey)
 		if err == nil {
 			config.ClientCAs = x509.NewCertPool()
 
@@ -121,15 +121,15 @@ func NewServerTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasV
 	return config, nil
 }
 
-// NewClientTLSConfig returns a new tls.VaultConfig from the given configuration input
+// NewClientTLSConfigContext returns a new tls.VaultConfig from the given configuration input
 //
-// deprecated: use NewClientTLSConfigContext instead
-func NewClientTLSConfig(cfg HasTLSConfig, vault HasVaultConfig) (*tls.Config, error) {
-	return NewClientTLSConfigContext(context.TODO(), cfg, vault)
+// deprecated: use NewClientTLSConfig instead
+func NewClientTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasVaultConfig) (*tls.Config, error) {
+	return NewClientTLSConfig(ctx, cfg, vault)
 }
 
-// NewClientTLSConfigContext returns a new tls.VaultConfig from the given configuration input
-func NewClientTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasVaultConfig) (*tls.Config, error) {
+// NewClientTLSConfig returns a new tls.VaultConfig from the given configuration input
+func NewClientTLSConfig(ctx context.Context, cfg HasTLSConfig, vault HasVaultConfig) (*tls.Config, error) {
 	ctx, span := tracer.Start(ctx, "NewClientTLSConfig")
 	defer span.End()
 
@@ -147,7 +147,7 @@ func NewClientTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasV
 	var err error
 	t := CloneTLSConfig(cfg)
 
-	err = GenerateCertificatesContext(ctx, vault, cfg.GetGenerate(), &t.Cert.Secret, &t.Key.Secret)
+	err = GenerateCertificates(ctx, vault, cfg.GetGenerate(), &t.Cert.Secret, &t.Key.Secret)
 	if err != nil {
 		err = errors.Wrap(err, "tls: failed to generate certificates")
 		span.RecordError(err)
@@ -155,14 +155,14 @@ func NewClientTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasV
 	}
 
 	if t.GetCert().GetEnabled() && t.GetKey().GetEnabled() {
-		certPEMBlock, err := LoadKeyContext(ctx, t.GetCert(), vault, TLSCertificateKey)
+		certPEMBlock, err := LoadKey(ctx, t.GetCert(), vault, TLSCertificateKey)
 		if err != nil {
 			err = errors.Wrap(err, "tls: failed to load certificate")
 			span.RecordError(err)
 			return nil, err
 		}
 
-		keyPEMBlock, err := LoadKeyContext(ctx, t.GetKey(), vault, TLSPrivateKey)
+		keyPEMBlock, err := LoadKey(ctx, t.GetKey(), vault, TLSPrivateKey)
 		if err != nil {
 			err = errors.Wrap(err, "tls: failed to load private key")
 			span.RecordError(err)
@@ -178,7 +178,7 @@ func NewClientTLSConfigContext(ctx context.Context, cfg HasTLSConfig, vault HasV
 		}
 
 		if t.GetRootCA().GetEnabled() {
-			rootcaPEMBlock, err := LoadKeyContext(ctx, t.GetRootCA(), vault, TLSRootCAKey)
+			rootcaPEMBlock, err := LoadKey(ctx, t.GetRootCA(), vault, TLSRootCAKey)
 			if err != nil {
 				err = errors.Wrap(err, "tls: failed to load RootCA certificates")
 				span.RecordError(err)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Implement ReadObject/WriteObject on Vault to support reading and writing objects, handling Vault's serialization foibles
2. Flip the *Context() methods to be deprecated and add ctx to original methods

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
