### PR TITLE
feat(object_store):  Modify write interface to return only error and …

### DIFF
--- a/parameter/noop.go
+++ b/parameter/noop.go
@@ -38,8 +38,8 @@ func (c noopStore) Read(ctx context.Context, p string) (map[string]interface{}, 
 	return nil, ErrNotFound
 }
 
-func (c noopStore) Write(ctx context.Context, p string, data map[string]interface{}) (map[string]interface{}, error) {
-	return make(map[string]interface{}), nil
+func (c noopStore) Write(ctx context.Context, p string, data map[string]interface{}) error {
+	return nil
 }
 
 func (c noopStore) Delete(ctx context.Context, p string) error {

--- a/parameter/object_store.go
+++ b/parameter/object_store.go
@@ -35,7 +35,7 @@ func (c *objectStore) Read(ctx context.Context, p string) (map[string]interface{
 	return c.store.Read(ctx, p)
 }
 
-func (c *objectStore) Write(ctx context.Context, p string, data map[string]interface{}) (map[string]interface{}, error) {
+func (c *objectStore) Write(ctx context.Context, p string, data map[string]interface{}) error {
 	return c.store.Write(ctx, p, data)
 }
 
@@ -219,7 +219,7 @@ func (c *objectStore) WriteObject(ctx context.Context, p string, in interface{})
 		}
 	}
 
-	if _, err := c.store.Write(ctx, p, m); err != nil {
+	if err := c.store.Write(ctx, p, m); err != nil {
 		return err
 	}
 

--- a/parameter/store.go
+++ b/parameter/store.go
@@ -31,6 +31,6 @@ var ErrNotFound = errors.New("not found")
 type Store interface {
 	List(ctx context.Context, p string) ([]string, error)
 	Read(ctx context.Context, p string) (map[string]interface{}, error)
-	Write(ctx context.Context, p string, data map[string]interface{}) (map[string]interface{}, error)
+	Write(ctx context.Context, p string, data map[string]interface{}) error
 	Delete(ctx context.Context, p string) error
 }


### PR DESCRIPTION
…not the secret data

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
> When we write to vault, vault doesn't return the secret data back.  So instead of returning (secret, error) we are returning error.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
