### PR TITLE
fix: use standard not found for parameter

### DIFF
--- a/parameter/noop.go
+++ b/parameter/noop.go
@@ -22,6 +22,7 @@ package parameter
 
 import (
 	"context"
+	"go.ketch.com/lib/orlop/v2/errors"
 )
 
 type noopStore struct{}
@@ -35,7 +36,7 @@ func (c noopStore) List(ctx context.Context, p string) ([]string, error) {
 }
 
 func (c noopStore) Read(ctx context.Context, p string) (map[string]interface{}, error) {
-	return nil, ErrNotFound
+	return nil, errors.NotFound(nil)
 }
 
 func (c noopStore) Write(ctx context.Context, p string, data map[string]interface{}) (map[string]interface{}, error) {

--- a/parameter/object_store.go
+++ b/parameter/object_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"go.ketch.com/lib/orlop/v2/errors"
 	"reflect"
 	"strings"
 )
@@ -56,11 +57,11 @@ func (c *objectStore) ReadObject(ctx context.Context, p string, out interface{})
 
 	sec, err := c.store.Read(ctx, p)
 	if err != nil {
-		return err
+		return errors.NotFound(err)
 	}
 
 	if sec == nil {
-		return ErrNotFound
+		return errors.NotFound(nil)
 	}
 
 	t := v.Type()
@@ -114,7 +115,7 @@ func (c *objectStore) ReadObject(ctx context.Context, p string, out interface{})
 				if j, ok := val.(string); ok {
 					b, err := base64.StdEncoding.DecodeString(j)
 					if err != nil {
-						return err
+						return errors.Invalid(err)
 					}
 
 					f.SetBytes(b)
@@ -220,7 +221,7 @@ func (c *objectStore) WriteObject(ctx context.Context, p string, in interface{})
 	}
 
 	if _, err := c.store.Write(ctx, p, m); err != nil {
-		return err
+		return errors.Conflict(err)
 	}
 
 	return nil

--- a/parameter/store.go
+++ b/parameter/store.go
@@ -22,10 +22,7 @@ package parameter
 
 import (
 	"context"
-	"go.ketch.com/lib/orlop/v2/errors"
 )
-
-var ErrNotFound = errors.New("not found")
 
 // Store provide an interface to interact with a parameter store
 type Store interface {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace `parameter.ErrNotFound` with a standard `NotFound`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Consistency

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
