### PR TITLE
fix: env var inconsistency

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -23,7 +23,6 @@ package orlop
 import (
 	"context"
 	"fmt"
-	"github.com/iancoleman/strcase"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.ketch.com/lib/orlop/v2/config"
@@ -33,7 +32,6 @@ import (
 	"go.ketch.com/lib/orlop/v2/service"
 	"go.uber.org/fx"
 	stdlog "log"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -205,7 +203,7 @@ func (r *Runner) runE(runner any, cfg any) func(cmd *cobra.Command, args []strin
 //
 // deprecated: use `cmd.Runner.Getenv`
 func (r *Runner) Getenv(key string) string {
-	return os.Getenv(strcase.ToScreamingSnake(strings.Join([]string{r.prefix, key}, "_")))
+	return config.GetEnv(r.prefix, key)
 }
 
 // SetupLogging sets up logging for the environment and the default log level

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,14 +24,12 @@ import (
 	"context"
 	"fmt"
 	stdlog "log"
-	"os"
 	"sort"
 	"strings"
 
 	"go.ketch.com/lib/orlop/v2"
 	"go.ketch.com/lib/orlop/v2/env"
 
-	"github.com/iancoleman/strcase"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"go.ketch.com/lib/orlop/v2/config"
@@ -183,7 +181,7 @@ func (r *Runner) runE(module fx.Option) func(cmd *cobra.Command, args []string) 
 
 // Getenv returns the value of the environment variable named `key`
 func (r *Runner) Getenv(key string) string {
-	return os.Getenv(strcase.ToScreamingSnake(strings.Join([]string{r.prefix, key}, "_")))
+	return config.GetEnv(r.prefix, key)
 }
 
 // SetupLogging sets up logging for the environment and the default log level

--- a/config/impl.go
+++ b/config/impl.go
@@ -23,6 +23,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -175,6 +176,15 @@ func (s *providerImpl) getVariablesFromConfig(service string, cfg any) ([]string
 	}
 
 	return vars, nil
+}
+
+func GetEnv(prefix string, key string) string {
+	return os.Getenv(GetPrefixKey(prefix, key))
+}
+
+func GetPrefixKey(prefix string, key string) string {
+	replacer := strings.NewReplacer("-", "_", ".", "_")
+	return toScreamingDelimited(replacer.Replace(strings.Join([]string{prefix, key}, "_")), '_', 0, true)
 }
 
 func toScreamingDelimited(s string, delimiter uint8, ignore uint8, screaming bool) string {

--- a/config/reflect.go
+++ b/config/reflect.go
@@ -70,9 +70,6 @@ func reflectStructValue(prefix []string, r map[string]*configField, v reflect.Va
 			continue
 		}
 
-		replacer := strings.NewReplacer("-", "_", ".", "_")
-		key := toScreamingDelimited(replacer.Replace(strings.Join(append(prefix, *tag.Name), "_")), '_', 0, true)
-
 		for ft.Kind() == reflect.Ptr {
 			ft = ft.Elem()
 		}
@@ -142,6 +139,8 @@ func reflectStructValue(prefix []string, r map[string]*configField, v reflect.Va
 				setter = pointerFieldSetter(setter)
 			}
 
+			key := GetPrefixKey(strings.Join(prefix, "_"), *tag.Name)
+			
 			r[key] = &configField{
 				tag: tag,
 				v:   f,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.16.0. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Fix inconsistencies in env var naming

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [X] I have informed stakeholders of my changes.
