### PR TITLE
feat: dump non-secret attested config

### DIFF
--- a/config/tag.go
+++ b/config/tag.go
@@ -30,6 +30,7 @@ type configTag struct {
 	Encoding     *string
 	DefaultValue *string
 	Required     bool
+	NotSecret    bool
 }
 
 func (t configTag) String() string {
@@ -47,6 +48,9 @@ func (t configTag) String() string {
 		s = append(s, "required")
 	} else {
 		s = append(s, "optional")
+	}
+	if t.NotSecret {
+		s = append(s, "not_secret")
 	}
 
 	return strings.Join(s, ", ")
@@ -71,6 +75,9 @@ func parseConfigTag(tag string) *configTag {
 
 		case "required":
 			t.Required = true
+
+		case "not_secret":
+			t.NotSecret = true
 
 		case "encoding":
 			switch elemParts[1] {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.0. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Dump non-secret attested config. This only honours the `--loglevel=trace` CLI parameter, not the `$SERVICE_LOG_LEVEL` variable.

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [X] I have informed stakeholders of my changes.
