### PR TITLE
feat: add support for options in cmd

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -77,9 +77,9 @@ func (r *Runner) SetupRoot(cmd *cobra.Command) *Runner {
 }
 
 // Setup sets up the Command
-func (r *Runner) Setup(cmd *cobra.Command, module fx.Option) *Runner {
+func (r *Runner) Setup(cmd *cobra.Command, options ...fx.Option) *Runner {
 	if cmd.RunE == nil {
-		cmd.RunE = r.runE(module)
+		cmd.RunE = r.runE(options...)
 	}
 
 	cmd.AddCommand(&cobra.Command{
@@ -95,7 +95,7 @@ func (r *Runner) Setup(cmd *cobra.Command, module fx.Option) *Runner {
 				fx.Supply(service.Name(r.prefix)),
 				fx.Supply(logging.FatalLevel),
 				orlop.Module,
-				module,
+				fx.Options(options...),
 				fx.Populate(&cfgMgr),
 			)
 
@@ -154,7 +154,7 @@ func (r *Runner) preRunE(cmd *cobra.Command, args []string) error {
 	return r.prevPreRunE(cmd, args)
 }
 
-func (r *Runner) runE(module fx.Option) func(cmd *cobra.Command, args []string) error {
+func (r *Runner) runE(options ...fx.Option) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		l := log.New()
 
@@ -170,7 +170,7 @@ func (r *Runner) runE(module fx.Option) func(cmd *cobra.Command, args []string) 
 			fx.Supply(service.Name(r.prefix)),
 			fx.Supply(logging.Level(loglevelFlag)),
 			orlop.Module,
-			module,
+			fx.Options(options...),
 		)
 
 		app.Run()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.0. DO NOT EDIT. -->

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Adds the capability to pass additional FX Options into the `Setup()` call for a command. This is required to apply options that must be applied to the parent app such as [StopTimeout](https://pkg.go.dev/go.uber.org/fx#StopTimeout)
## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test added in `cmd_test.go` that shows how you can alter the behavior of the fx App by passing in additional options to the `.Setup` call. The test has two cases, the first showcases the fx App exiting with an error during shutdown due to a timeout and the second shows how by passing in an option to increase the shutdown window the App no longer exits with an error.
## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
