### PR TITLE
fix: upgrade conventional-actions to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0
     - name: Generate next version
       id: version
-      uses: conventional-actions/next-version@c6672ae04a946e12f361b119d3fd8fbb3388c0d9 # v1
+      uses: conventional-actions/next-version@1b3e4803a0bdf7435ba7bb5ace077445ed54e82a # v1.1.8
     - name: Setup .netrc
       uses: conventional-actions/setup-netrc@4f85df605083085682fc078d17b5d15e439a924e # v1
     - name: Setup Go
@@ -51,7 +51,7 @@ jobs:
       contents: write
     steps:
     - name: Create Release
-      uses: conventional-actions/create-release@34d9f18903870e1622247562884dcbe27bbe0622 # v1
+      uses: conventional-actions/create-release@c025b7306d14a25901b72486f97f3ebe7662a8ed # v1.0.31
       with:
         tag_name: ${{ needs.build.outputs.version }}
 


### PR DESCRIPTION
## Summary

Upgrade conventional-actions to node24-compatible releases:

- `conventional-actions/next-version` → **v1.1.8** (`1b3e480`)
- `conventional-actions/create-release` → **v1.0.31** (`c025b73`)

Node 20 reaches EOL April 2026 and GitHub is forcing migration to node24 by June 2026.

### Upstream PRs

- https://github.com/conventional-actions/next-version/pull/96
- https://github.com/conventional-actions/create-release/pull/8

## Test plan

- [ ] CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates pinned GitHub Action versions for versioning and release creation, with no changes to application code or build logic.
> 
> **Overview**
> Updates `.github/workflows/ci.yml` to pin `conventional-actions/next-version` to `v1.1.8` and `conventional-actions/create-release` to `v1.0.31` (Node 24-compatible releases), leaving the rest of the CI and release flow unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb175739fc0f8e4f824581363f5d1113bcbf298c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->